### PR TITLE
[IN-95] Middleware implementation from Auth.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11295,9 +11295,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -12562,6 +12562,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -21056,6 +21057,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -22291,9 +22293,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11295,9 +11295,10 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -22293,9 +22294,10 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,32 +1,30 @@
 import { defaultLocale, locales } from "@/config/i18n/locales"
 import { auth } from "@/lib/auth"
 import createMiddleware from "next-intl/middleware"
-import { NextRequest, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 
-export default async function middleware(request: NextRequest) {
-  const session = await auth()
-
-  if (!request.nextUrl.pathname.startsWith("/admin")) {
+export default auth((req) => {
+  if (!req.nextUrl.pathname.startsWith("/admin")) {
     const handleI18nRouting = createMiddleware({
       locales,
       defaultLocale
     })
-    const res = handleI18nRouting(request)
-    const languageFromCookies = request.cookies.get("NEXT_LOCALE")?.value || defaultLocale
+    const res = handleI18nRouting(req)
+    const languageFromCookies = req.cookies.get("NEXT_LOCALE")?.value || defaultLocale
 
-    if (!session?.user && !isRedirecting(request.url)) {
-      return NextResponse.redirect(new URL(`/${languageFromCookies}/login`, request.url))
+    if (!req.auth?.user && !isRedirecting(req.url)) {
+      return NextResponse.redirect(new URL(`/${languageFromCookies}/login`, req.url))
     }
 
     return res
   }
 
-  if (!session?.user.isAdmin) {
-    return NextResponse.redirect(new URL("/", request.url))
+  if (!req.auth?.user.isAdmin) {
+    return NextResponse.redirect(new URL("/", req.url))
   }
 
-  return null
-}
+  return NextResponse.next()
+})
 
 export const config = {
   matcher: ["/", "/(en|es|fr|ja|pt|zh)/:path*", "/login", "/admin/:path*"]


### PR DESCRIPTION
Linked to this ticket: https://instamint-deva.atlassian.net/browse/IN-95

The ticket was about the warnings while building the app:

```
./node_modules/bcryptjs/dist/bcrypt.js
A Node.js API is used (process.nextTick at line: 351) which is not supported in the Edge Runtime.
Learn more: https://nextjs.org/docs/api-reference/edge-runtime

Import trace for requested module:
./node_modules/bcryptjs/dist/bcrypt.js
./src/lib/auth.ts
```

But I didn't find any way to avoid it without using the old version of the library or using a database session strategy (https://github.com/vercel/next.js/discussions/62985)
I'm still asking for PR because I changed the middleware to follow the one in Auth.js docs:
https://authjs.dev/getting-started/session-management/protecting#nextjs-middleware

